### PR TITLE
Add Flask whisper transcription app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# AudioTranscribe
+
+Simple Flask application for transcribing audio files with OpenAI Whisper API.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export your OpenAI API key:
+   ```bash
+   export OPENAI_API_KEY=your-key-here
+   ```
+3. Run the application:
+   ```bash
+   python app.py
+   ```
+
+Open `http://localhost:5000` in your browser to upload an audio file and download the transcription.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+
+from flask import Flask, render_template, request, send_file, redirect, url_for, flash
+import openai
+from werkzeug.utils import secure_filename
+
+app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", "change-me")
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/upload", methods=["POST"])
+def upload():
+    audio_file = request.files.get("audio_file")
+    if not audio_file:
+        flash("No file uploaded")
+        return redirect(url_for("index"))
+
+    filename = secure_filename(audio_file.filename)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(filename)[1]) as tmp:
+        audio_path = tmp.name
+        audio_file.save(audio_path)
+
+    try:
+        with open(audio_path, "rb") as f:
+            transcript = openai.Audio.transcribe("whisper-1", f)
+        text = transcript["text"]
+    except Exception as exc:
+        flash(f"Transcription failed: {exc}")
+        os.remove(audio_path)
+        return redirect(url_for("index"))
+
+    os.remove(audio_path)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".txt", mode="w", encoding="utf-8") as tf:
+        tf.write(text)
+        tf.flush()
+        transcript_path = tf.name
+
+    return send_file(transcript_path, as_attachment=True,
+                     download_name="transcript.txt", mimetype="text/plain")
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+openai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Audio Transcription</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        #loading { display: none; text-align: center; }
+        .spinner {
+            border: 8px solid #f3f3f3;
+            border-top: 8px solid #3498db;
+            border-radius: 50%;
+            width: 60px;
+            height: 60px;
+            animation: spin 2s linear infinite;
+            margin: auto;
+            margin-top: 20px;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
+    <script>
+        function showLoading() {
+            document.getElementById('loading').style.display = 'block';
+        }
+    </script>
+</head>
+<body>
+<h1>Audio Transcription</h1>
+<form method="post" action="/upload" enctype="multipart/form-data" onsubmit="showLoading()">
+    <input type="file" name="audio_file" accept="audio/*" required>
+    <button type="submit">Upload and Transcribe</button>
+</form>
+<div id="loading">
+    <div class="spinner"></div>
+    <p>Transcribing...</p>
+</div>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul style="color:red;">
+    {% for message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build simple Flask web app to upload audio files
- send file to OpenAI Whisper API and return transcription
- show loading spinner during transcription and error messages when needed
- document setup in README

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6847efcf926883299891f382a66c6c0b